### PR TITLE
Add entitlement for opening/saving patch files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
+# Xcode
 xcuserdata
+
+# macOS
+.DS_Store

--- a/MIDI Patchbay.entitlements
+++ b/MIDI Patchbay.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
This PR adds the missing entitlement to open/save patch files outside of the app sandbox. This is needed for the open & save dialogs to work as before on newer macOS versions. This fix was suggested by @axmonti [here](https://github.com/notahat/midi_patchbay/issues/7#issuecomment-879959049).

I also added .DS_Store (Spotlight dir index files) to the gitignore.